### PR TITLE
Add Filipino-Philippine peso (fil-PH)

### DIFF
--- a/languages.js
+++ b/languages.js
@@ -43,7 +43,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : danish denmark (dk)
  * author : Michael Storgaard : https://github.com/mstorgaard
@@ -87,7 +87,7 @@
         this.numbro.language('da-DK', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : German (de) – generally useful in Germany, Austria, Luxembourg, Belgium
  * author : Marco Krage : https://github.com/sinky
@@ -131,11 +131,11 @@
         this.numbro.language('de-DE', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : German in Switzerland (de-ch)
  * author : Michael Piefel : https://github.com/piefel (based on work from Marco Krage : https://github.com/sinky)
- */ 
+ */
 (function () {
     var language = {
         delimiters: {
@@ -175,7 +175,7 @@
         this.numbro.language('de-CH', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : english united kingdom (uk)
  * author : Dan Ristic : https://github.com/dristic
@@ -223,7 +223,7 @@
         this.numbro.language('en-GB', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : spanish
  * author : Hernan Garcia : https://github.com/hgarcia
@@ -244,7 +244,7 @@
             var b = number % 10;
             return (b === 1 || b === 3) ? 'er' :
                 (b === 2) ? 'do' :
-                (b === 7 || b === 0) ? 'mo' : 
+                (b === 7 || b === 0) ? 'mo' :
 		(b === 8) ? 'vo' :
 		(b === 9) ? 'no' : 'to';
         },
@@ -273,7 +273,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : spanish Spain
  * author : Hernan Garcia : https://github.com/hgarcia
@@ -323,7 +323,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : Estonian
  * author : Illimar Tambek : https://github.com/ragulka
@@ -371,7 +371,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : Finnish
  * author : Sami Saada : https://github.com/samitheberber
@@ -460,7 +460,7 @@
         this.numbro.language('fr-CA', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : french (fr-ch)
  * author : Adam Draper : https://github.com/adamwdraper
@@ -505,7 +505,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : french (fr)
  * author : Adam Draper : https://github.com/adamwdraper
@@ -593,7 +593,7 @@
         this.numbro.language('hu-HU', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : italian Italy (it)
  * author : Giacomo Trombi : http://cinquepunti.it
@@ -637,7 +637,7 @@
         this.numbro.language('it-IT', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : japanese
  * author : teppeis : https://github.com/teppeis
@@ -726,7 +726,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : norwegian
  * author : Benjamin Van Ryseghem
@@ -767,7 +767,7 @@
 		this.numbro.language('nb-NO', language);
 	}
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : belgium-dutch (be-nl)
  * author : Dieter Luypaert : https://github.com/moeriki
@@ -812,7 +812,7 @@
         this.numbro.language('nl-BE', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : netherlands-dutch (nl-nl)
  * author : Dave Clayton : https://github.com/davedx
@@ -857,7 +857,7 @@
         this.numbro.language('nl-NL', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : polish (pl)
  * author : Dominik Bulaj : https://github.com/dominikbulaj
@@ -901,7 +901,7 @@
         this.numbro.language('pl-PL', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : portuguese brazil (pt-br)
  * author : Ramiro Varandas Jr : https://github.com/ramirovjr
@@ -945,7 +945,7 @@
         this.numbro.language('pt-BR', language);
     }
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : portuguese (pt-pt)
  * author : Diogo Resende : https://github.com/dresende
@@ -990,7 +990,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : russian (ru)
  * author : Anatoli Papirovski : https://github.com/apapirovski
@@ -1008,10 +1008,10 @@
             trillion: 't'
         },
         ordinal: function () {
-            // not ideal, but since in Russian it can taken on 
+            // not ideal, but since in Russian it can taken on
             // different forms (masculine, feminine, neuter)
             // this is all we can do
-            return '.'; 
+            return '.';
         },
         currency: {
             symbol: 'руб.',
@@ -1054,10 +1054,10 @@
             trillion: 't'
         },
         ordinal: function () {
-            // not ideal, but since in Russian it can taken on 
+            // not ideal, but since in Russian it can taken on
             // different forms (masculine, feminine, neuter)
             // this is all we can do
-            return '.'; 
+            return '.';
         },
         currency: {
             symbol: '\u20B4',
@@ -1170,7 +1170,7 @@
 		this.numbro.language('sv-SE', language);
 	}
 }());
-/*! 
+/*!
  * numbro.js language configuration
  * language : thai (th)
  * author : Sathit Jittanupat : https://github.com/jojosati
@@ -1215,7 +1215,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : turkish (tr)
  * author : Ecmel Ercan : https://github.com/ecmel, Erhan Gundogan : https://github.com/erhangundogan, Burak Yiğit Kaya: https://github.com/BYK
@@ -1309,10 +1309,10 @@
             trillion: 'блн'
         },
         ordinal: function () {
-            // not ideal, but since in Ukrainian it can taken on 
+            // not ideal, but since in Ukrainian it can taken on
             // different forms (masculine, feminine, neuter)
             // this is all we can do
-            return ''; 
+            return '';
         },
         currency: {
             symbol: '\u20B4',
@@ -1339,7 +1339,7 @@
     }
 }());
 
-/*! 
+/*!
  * numbro.js language configuration
  * language : simplified chinese
  * author : badplum : https://github.com/badplum

--- a/languages/da-DK.js
+++ b/languages/da-DK.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : danish denmark (dk)
  * author : Michael Storgaard : https://github.com/mstorgaard

--- a/languages/de-DE.js
+++ b/languages/de-DE.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : German (de) – generally useful in Germany, Austria, Luxembourg, Belgium
  * author : Marco Krage : https://github.com/sinky

--- a/languages/de-ch.js
+++ b/languages/de-ch.js
@@ -1,8 +1,8 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : German in Switzerland (de-ch)
  * author : Michael Piefel : https://github.com/piefel (based on work from Marco Krage : https://github.com/sinky)
- */ 
+ */
 (function () {
     var language = {
         delimiters: {

--- a/languages/en-GB.js
+++ b/languages/en-GB.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : english united kingdom (uk)
  * author : Dan Ristic : https://github.com/dristic

--- a/languages/es-AR.js
+++ b/languages/es-AR.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : spanish
  * author : Hernan Garcia : https://github.com/hgarcia
@@ -19,7 +19,7 @@
             var b = number % 10;
             return (b === 1 || b === 3) ? 'er' :
                 (b === 2) ? 'do' :
-                (b === 7 || b === 0) ? 'mo' : 
+                (b === 7 || b === 0) ? 'mo' :
 		(b === 8) ? 'vo' :
 		(b === 9) ? 'no' : 'to';
         },

--- a/languages/es-ES.js
+++ b/languages/es-ES.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : spanish Spain
  * author : Hernan Garcia : https://github.com/hgarcia

--- a/languages/et-EE.js
+++ b/languages/et-EE.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : Estonian
  * author : Illimar Tambek : https://github.com/ragulka

--- a/languages/fi-FI.js
+++ b/languages/fi-FI.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : Finnish
  * author : Sami Saada : https://github.com/samitheberber

--- a/languages/fil-PH.js
+++ b/languages/fil-PH.js
@@ -33,6 +33,6 @@
     }
     // Browser
     if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
-        this.numeral.language('fil-ph', language);
+        this.numeral.language('fil-PH', language);
     }
 }());

--- a/languages/fil-PH.js
+++ b/languages/fil-PH.js
@@ -1,5 +1,5 @@
 /*!
- * numeral.js language configuration
+ * numbro.js language configuration
  * language : filipino philippines (ph)
  * author : Michael Abadilla : https://github.com/mjmaix
  */
@@ -32,7 +32,7 @@
         module.exports = language;
     }
     // Browser
-    if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
-        this.numeral.language('fil-PH', language);
+    if (typeof window !== 'undefined' && this.numbro && this.numbro.language) {
+        this.numbro.language('fil-PH', language);
     }
 }());

--- a/languages/fil-ph.js
+++ b/languages/fil-ph.js
@@ -1,0 +1,38 @@
+/*!
+ * numeral.js language configuration
+ * language : filipino philippines (ph)
+ * author : Michael Abadilla : https://github.com/mjmaix
+ */
+(function () {
+    var language = {
+        delimiters: {
+            thousands: ',',
+            decimal: '.'
+        },
+        abbreviations: {
+            thousand: 'k',
+            million: 'm',
+            billion: 'b',
+            trillion: 't'
+        },
+        ordinal: function (number) {
+            var b = number % 10;
+            return (~~ (number % 100 / 10) === 1) ? 'th' :
+                (b === 1) ? 'st' :
+                (b === 2) ? 'nd' :
+                (b === 3) ? 'rd' : 'th';
+        },
+        currency: {
+            symbol: '₱'
+        }
+    };
+
+    // Node
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = language;
+    }
+    // Browser
+    if (typeof window !== 'undefined' && this.numeral && this.numeral.language) {
+        this.numeral.language('fil-ph', language);
+    }
+}());

--- a/languages/fr-CH.js
+++ b/languages/fr-CH.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : french (fr-ch)
  * author : Adam Draper : https://github.com/adamwdraper

--- a/languages/fr-FR.js
+++ b/languages/fr-FR.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : french (fr)
  * author : Adam Draper : https://github.com/adamwdraper

--- a/languages/it-IT.js
+++ b/languages/it-IT.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : italian Italy (it)
  * author : Giacomo Trombi : http://cinquepunti.it

--- a/languages/ja-JP.js
+++ b/languages/ja-JP.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : japanese
  * author : teppeis : https://github.com/teppeis

--- a/languages/nb-NO.js
+++ b/languages/nb-NO.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : norwegian
  * author : Benjamin Van Ryseghem

--- a/languages/nl-BE.js
+++ b/languages/nl-BE.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : belgium-dutch (be-nl)
  * author : Dieter Luypaert : https://github.com/moeriki

--- a/languages/nl-NL.js
+++ b/languages/nl-NL.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : netherlands-dutch (nl-nl)
  * author : Dave Clayton : https://github.com/davedx

--- a/languages/pl-PL.js
+++ b/languages/pl-PL.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : polish (pl)
  * author : Dominik Bulaj : https://github.com/dominikbulaj

--- a/languages/pt-BR.js
+++ b/languages/pt-BR.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : portuguese brazil (pt-br)
  * author : Ramiro Varandas Jr : https://github.com/ramirovjr

--- a/languages/pt-PT.js
+++ b/languages/pt-PT.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : portuguese (pt-pt)
  * author : Diogo Resende : https://github.com/dresende

--- a/languages/ru-RU.js
+++ b/languages/ru-RU.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : russian (ru)
  * author : Anatoli Papirovski : https://github.com/apapirovski
@@ -16,10 +16,10 @@
             trillion: 't'
         },
         ordinal: function () {
-            // not ideal, but since in Russian it can taken on 
+            // not ideal, but since in Russian it can taken on
             // different forms (masculine, feminine, neuter)
             // this is all we can do
-            return '.'; 
+            return '.';
         },
         currency: {
             symbol: 'руб.',

--- a/languages/ru-UA.js
+++ b/languages/ru-UA.js
@@ -14,10 +14,10 @@
             trillion: 't'
         },
         ordinal: function () {
-            // not ideal, but since in Russian it can taken on 
+            // not ideal, but since in Russian it can taken on
             // different forms (masculine, feminine, neuter)
             // this is all we can do
-            return '.'; 
+            return '.';
         },
         currency: {
             symbol: '\u20B4',

--- a/languages/th-TH.js
+++ b/languages/th-TH.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : thai (th)
  * author : Sathit Jittanupat : https://github.com/jojosati

--- a/languages/tr-TR.js
+++ b/languages/tr-TR.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : turkish (tr)
  * author : Ecmel Ercan : https://github.com/ecmel, Erhan Gundogan : https://github.com/erhangundogan, Burak Yiğit Kaya: https://github.com/BYK

--- a/languages/uk-UA.js
+++ b/languages/uk-UA.js
@@ -14,10 +14,10 @@
             trillion: 'блн'
         },
         ordinal: function () {
-            // not ideal, but since in Ukrainian it can taken on 
+            // not ideal, but since in Ukrainian it can taken on
             // different forms (masculine, feminine, neuter)
             // this is all we can do
-            return ''; 
+            return '';
         },
         currency: {
             symbol: '\u20B4',

--- a/languages/zh-CN.js
+++ b/languages/zh-CN.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * numbro.js language configuration
  * language : simplified chinese
  * author : badplum : https://github.com/badplum

--- a/tests/languages/fil-PH.js
+++ b/tests/languages/fil-PH.js
@@ -1,16 +1,16 @@
-var numeral = require('../../numeral'),
+var numbro = require('../../numbro'),
     language = require('../../languages/fil-PH');
 
-numeral.language('fil-PH', language);
+numbro.language('fil-PH', language);
 
 exports['language:fil-PH'] = {
     setUp: function (callback) {
-        numeral.language('fil-PH');
+        numbro.language('fil-PH');
         callback();
     },
 
     tearDown: function (callback) {
-        numeral.language('en');
+        numbro.language('en-US');
         callback();
     },
 
@@ -37,7 +37,7 @@ exports['language:fil-PH'] = {
         ];
 
         for (var i = 0; i < tests.length; i++) {
-            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+            test.strictEqual(numbro(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
         }
 
         test.done();
@@ -54,7 +54,7 @@ exports['language:fil-PH'] = {
         ];
 
         for (var i = 0; i < tests.length; i++) {
-            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+            test.strictEqual(numbro(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
         }
 
         test.done();
@@ -71,7 +71,7 @@ exports['language:fil-PH'] = {
         ];
 
         for (var i = 0; i < tests.length; i++) {
-            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+            test.strictEqual(numbro(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
         }
 
         test.done();
@@ -93,7 +93,7 @@ exports['language:fil-PH'] = {
         ];
 
         for (var i = 0; i < tests.length; i++) {
-            test.strictEqual(numeral().unformat(tests[i][0]), tests[i][1], tests[i][0]);
+            test.strictEqual(numbro().unformat(tests[i][0]), tests[i][1], tests[i][0]);
         }
 
         test.done();

--- a/tests/languages/fil-PH.js
+++ b/tests/languages/fil-PH.js
@@ -1,11 +1,11 @@
 var numeral = require('../../numeral'),
-    language = require('../../languages/fil-ph');
+    language = require('../../languages/fil-PH');
 
-numeral.language('fil-ph', language);
+numeral.language('fil-PH', language);
 
-exports['language:fil-ph'] = {
+exports['language:fil-PH'] = {
     setUp: function (callback) {
-        numeral.language('fil-ph');
+        numeral.language('fil-PH');
         callback();
     },
 

--- a/tests/languages/fil-ph.js
+++ b/tests/languages/fil-ph.js
@@ -1,0 +1,101 @@
+var numeral = require('../../numeral'),
+    language = require('../../languages/fil-ph');
+
+numeral.language('fil-ph', language);
+
+exports['language:fil-ph'] = {
+    setUp: function (callback) {
+        numeral.language('fil-ph');
+        callback();
+    },
+
+    tearDown: function (callback) {
+        numeral.language('en');
+        callback();
+    },
+
+    format: function (test) {
+        test.expect(16);
+
+        var tests = [
+            [10000,'0,0.0000','10,000.0000'],
+            [10000.23,'0,0','10,000'],
+            [-10000,'0,0.0','-10,000.0'],
+            [10000.1234,'0.000','10000.123'],
+            [-10000,'(0,0.0000)','(10,000.0000)'],
+            [-0.23,'.00','-.23'],
+            [-0.23,'(.00)','(.23)'],
+            [0.23,'0.00000','0.23000'],
+            [1230974,'0.0a','1.2m'],
+            [1460,'0a','1k'],
+            [-104000,'0a','-104k'],
+            [1,'0o','1st'],
+            [52,'0o','52nd'],
+            [23,'0o','23rd'],
+            [100,'0o','100th'],
+            [1,'0[.]0','1']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    currency: function (test) {
+        test.expect(4);
+
+        var tests = [
+            [1000.234,'$0,0.00','₱1,000.23'],
+            [-1000.234,'($0,0)','(₱1,000)'],
+            [-1000.234,'$0.00','-₱1000.23'],
+            [1230974,'($0.00a)','₱1.23m']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    percentages: function (test) {
+        test.expect(4);
+
+        var tests = [
+            [1,'0%','100%'],
+            [0.974878234,'0.000%','97.488%'],
+            [-0.43,'0%','-43%'],
+            [0.43,'(0.000%)','43.000%']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numeral(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    unformat: function (test) {
+        test.expect(9);
+
+        var tests = [
+            ['10,000.123',10000.123],
+            ['(0.12345)',-0.12345],
+            ['(₱1.23m)',-1230000],
+            ['10k',10000],
+            ['-10k',-10000],
+            ['23rd',23],
+            ['₱10,000.00',10000],
+            ['-76%',-0.76],
+            ['2:23:57',8637]
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numeral().unformat(tests[i][0]), tests[i][1], tests[i][0]);
+        }
+
+        test.done();
+    }
+};

--- a/tests/numbro/misc.js
+++ b/tests/numbro/misc.js
@@ -89,35 +89,35 @@ exports.misc = {
 
         test.done();
     },
-    
+
     languageData: function(test) {
         test.expect(10);
-        
+
         var cOld = '$',
             cNew = '!',
             formatTestVal = function() { return numbro('100').format('$0,0') },
             oldCurrencyVal = cOld + '100',
             newCurrencyVal = cNew + '100';
-        
+
         test.strictEqual(numbro.languageData().currency.symbol, cOld, 'Current language currency is ' + cOld);
         test.strictEqual(numbro.languageData('en-US').currency.symbol, cOld, 'English language currency is ' + cOld);
-        
+
         numbro.languageData().currency.symbol = cNew;
         test.strictEqual(numbro.languageData().currency.symbol, cNew, 'Current language currency is changed to ' + cNew);
         test.strictEqual(formatTestVal(), newCurrencyVal, 'Format uses new currency');
-        
+
         numbro.languageData().currency.symbol = cOld;
         test.strictEqual(numbro.languageData().currency.symbol, '$', 'Current language currency is reset to ' + cOld);
         test.strictEqual(formatTestVal(), oldCurrencyVal, 'Format uses old currency');
-        
+
         numbro.languageData('en-US').currency.symbol = cNew;
         test.strictEqual(numbro.languageData().currency.symbol, cNew, 'English language currency is changed to ' + cNew);
         test.strictEqual(formatTestVal(), newCurrencyVal, 'Format uses new currency');
-        
+
         numbro.languageData('en-US').currency.symbol = cOld;
         test.strictEqual(numbro.languageData().currency.symbol, cOld, 'English language currency is reset to ' + cOld);
         test.strictEqual(formatTestVal(), oldCurrencyVal, 'Format uses old currency');
-        
+
         test.done();
     }
 };

--- a/tests/numbro/validate.js
+++ b/tests/numbro/validate.js
@@ -21,7 +21,7 @@ exports.validate = {
 			['1.000,123', false],
 			['1000.', false],
 			['1000,', false],
-			['10..00', false],			
+			['10..00', false],
 			['10,,00', false],
 			['10, 00', false]
 		];


### PR DESCRIPTION
Rebase to bring in https://github.com/adamwdraper/Numeral-js/pull/191 by @mjmaix

Original PR
>This is the localisation for Filipino-Philippine peso (fil-ph).
>This is different from Tagalog-Philippine peso (tl-ph).