### PR TITLE
fix context issue when in strict mode

### DIFF
--- a/languages/cs-CZ.js
+++ b/languages/cs-CZ.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/da-DK.js
+++ b/languages/da-DK.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/de-CH.js
+++ b/languages/de-CH.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/de-DE.js
+++ b/languages/de-DE.js
@@ -47,4 +47,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/en-GB.js
+++ b/languages/en-GB.js
@@ -49,4 +49,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/en-ZA.js
+++ b/languages/en-ZA.js
@@ -49,4 +49,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/es-AR.js
+++ b/languages/es-AR.js
@@ -50,4 +50,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/es-ES.js
+++ b/languages/es-ES.js
@@ -50,4 +50,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/et-EE.js
+++ b/languages/et-EE.js
@@ -48,4 +48,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/fa-IR.js
+++ b/languages/fa-IR.js
@@ -35,4 +35,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/fi-FI.js
+++ b/languages/fi-FI.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/fil-PH.js
+++ b/languages/fil-PH.js
@@ -39,4 +39,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/fr-CA.js
+++ b/languages/fr-CA.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/fr-CH.js
+++ b/languages/fr-CH.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/fr-FR.js
+++ b/languages/fr-FR.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/hu-HU.js
+++ b/languages/hu-HU.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/it-IT.js
+++ b/languages/it-IT.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/ja-JP.js
+++ b/languages/ja-JP.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/lv-LV.js
+++ b/languages/lv-LV.js
@@ -44,4 +44,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/nb-NO.js
+++ b/languages/nb-NO.js
@@ -42,4 +42,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/nl-BE.js
+++ b/languages/nl-BE.js
@@ -46,4 +46,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/nl-NL.js
+++ b/languages/nl-NL.js
@@ -46,4 +46,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/pl-PL.js
+++ b/languages/pl-PL.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/pt-BR.js
+++ b/languages/pt-BR.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/pt-PT.js
+++ b/languages/pt-PT.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/ru-RU.js
+++ b/languages/ru-RU.js
@@ -48,4 +48,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/ru-UA.js
+++ b/languages/ru-UA.js
@@ -48,4 +48,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/sk-SK.js
+++ b/languages/sk-SK.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/sv-SE.js
+++ b/languages/sv-SE.js
@@ -42,4 +42,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/th-TH.js
+++ b/languages/th-TH.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/tr-TR.js
+++ b/languages/tr-TR.js
@@ -80,4 +80,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/uk-UA.js
+++ b/languages/uk-UA.js
@@ -48,4 +48,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/languages/zh-CN.js
+++ b/languages/zh-CN.js
@@ -45,4 +45,4 @@
     if (typeof window !== 'undefined' && window.numbro && window.numbro.language) {
         window.numbro.language(language.langLocaleCode, language);
     }
-}());
+}.call(typeof window === 'undefined' ? this : window));

--- a/numbro.js
+++ b/numbro.js
@@ -975,4 +975,4 @@
             return numbro;
         });
     }
-}).call(this);
+}.call(typeof window === 'undefined' ? this : window));


### PR DESCRIPTION
I'm using `numbro` with `browserify` and a `babel` transform (`babelify`), which wraps everything with strict mode (`'use strict';`).

This makes the value of `this` changes to `undefined` when used outside of a binding/instance scope.

As you pass either nothing or `this` to your IFFIs, it breaks when its used with strict mode, as `this` doesn't resolve to `window`/`global` anymore.

This PR fixes that issue.

N.B: I did not add any tests, as it would require adding a lot of `devDependencies` which are only factual for my specific case.