### PR TITLE
Properly set the `spaceSeparated` option on language definitions

### DIFF
--- a/languages/cs-CZ.js
+++ b/languages/cs-CZ.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: 'Kč',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/da-DK.js
+++ b/languages/da-DK.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: 'kr',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/de-CH.js
+++ b/languages/de-CH.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: 'CHF',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/de-DE.js
+++ b/languages/de-DE.js
@@ -26,7 +26,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/en-GB.js
+++ b/languages/en-GB.js
@@ -28,7 +28,8 @@
         },
         currency: {
             symbol: '£',
-            position: 'prefix'
+            position: 'prefix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/en-ZA.js
+++ b/languages/en-ZA.js
@@ -28,7 +28,8 @@
         },
         currency: {
             symbol: 'R',
-            position: 'prefix'
+            position: 'prefix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/es-AR.js
+++ b/languages/es-AR.js
@@ -29,7 +29,8 @@
         },
         currency: {
             symbol: '$',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/es-ES.js
+++ b/languages/es-ES.js
@@ -29,7 +29,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/et-EE.js
+++ b/languages/et-EE.js
@@ -27,7 +27,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/fi-FI.js
+++ b/languages/fi-FI.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/fr-CA.js
+++ b/languages/fr-CA.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '$',
-            position: 'prefix'
+            position: 'prefix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/fr-CH.js
+++ b/languages/fr-CH.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: 'CHF',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/fr-FR.js
+++ b/languages/fr-FR.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/he-IL.js
+++ b/languages/he-IL.js
@@ -21,7 +21,8 @@
         },
         currency: {
             symbol: '₪',
-            position: 'prefix'
+            position: 'prefix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/hu-HU.js
+++ b/languages/hu-HU.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: ' Ft',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/it-IT.js
+++ b/languages/it-IT.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/ja-JP.js
+++ b/languages/ja-JP.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '¥',
-            position: 'prefix'
+            position: 'prefix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/lv-LV.js
+++ b/languages/lv-LV.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/nb-NO.js
+++ b/languages/nb-NO.js
@@ -21,7 +21,8 @@
         },
         currency: {
             symbol: 'kr',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/nl-BE.js
+++ b/languages/nl-BE.js
@@ -25,7 +25,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/nl-NL.js
+++ b/languages/nl-NL.js
@@ -25,7 +25,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/pl-PL.js
+++ b/languages/pl-PL.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: ' zł',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/pt-BR.js
+++ b/languages/pt-BR.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: 'R$',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/pt-PT.js
+++ b/languages/pt-PT.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/ru-RU.js
+++ b/languages/ru-RU.js
@@ -27,7 +27,8 @@
         },
         currency: {
             symbol: 'руб.',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/ru-UA.js
+++ b/languages/ru-UA.js
@@ -27,7 +27,8 @@
         },
         currency: {
             symbol: '\u20B4',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/sk-SK.js
+++ b/languages/sk-SK.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '€',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/sv-SE.js
+++ b/languages/sv-SE.js
@@ -21,7 +21,8 @@
         },
         currency: {
             symbol: 'kr',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/th-TH.js
+++ b/languages/th-TH.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '฿',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/tr-TR.js
+++ b/languages/tr-TR.js
@@ -59,7 +59,8 @@
             },
             currency: {
                 symbol: '\u20BA',
-                position: 'postfix'
+                position: 'postfix',
+                spaceSeparated: true
             },
             defaults: {
                 currencyFormat: ',0000 a'

--- a/languages/uk-UA.js
+++ b/languages/uk-UA.js
@@ -27,7 +27,8 @@
         },
         currency: {
             symbol: '\u20B4',
-            position: 'postfix'
+            position: 'postfix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'

--- a/languages/zh-CN.js
+++ b/languages/zh-CN.js
@@ -24,7 +24,8 @@
         },
         currency: {
             symbol: '¥',
-            position: 'prefix'
+            position: 'prefix',
+            spaceSeparated: true
         },
         defaults: {
             currencyFormat: ',0000 a'


### PR DESCRIPTION
It seems that language definitions have overlooked the `spaceSeparated` option which tells numbro if it should leave a space between the currency symbol and the figure.

Taking the example of French,

    numbro.language('fr-FR')(42).formatCurrency('0,0')

yields `42€` instead of `42 €`.

This patch sets the `currency.spaceSperated` option on every language definition that needs it, according to `format.fullWithTwoDecimals`.