### PR TITLE
Fix #118 : make numbro work with forever

### DIFF
--- a/numbro.js
+++ b/numbro.js
@@ -1015,7 +1015,7 @@
     function inNodejsRuntime() {
         return (typeof process !== 'undefined') &&
             (process.browser === undefined) &&
-            (process.title === 'node' || process.title === 'grunt');
+            (process.versions.node !== undefined || process.title === 'grunt');
     }
 
     /************************************


### PR DESCRIPTION
Check process.versions.node !== undefined instead of process.title, which is not always 'node'.
Closes #118