### PR TITLE
Add existence check for require

### DIFF
--- a/numbro.js
+++ b/numbro.js
@@ -995,7 +995,8 @@
     function inNodejsRuntime() {
         return (typeof process !== 'undefined') &&
             (process.browser === undefined) &&
-            (process.title === 'node' || process.title === 'grunt');
+            (process.title === 'node' || process.title === 'grunt') &&
+            (typeof require !== 'undefined');
     }
 
     /************************************


### PR DESCRIPTION
In Meteor you can have a node environment but still no access to the require function. If there is no require function then it should not try to require `./languages`, because it can't. This will probably be solved in Meteor 1.3.