### PR TITLE
Improve verbatim feature

### DIFF
--- a/numbro.js
+++ b/numbro.js
@@ -140,14 +140,15 @@
 
     // determine what type of formatting we need to do
     function formatNumbro(n, format, roundingFunction) {
-        var output;
+        var output,
+            escapedFormat = format.replace(/\{[^\{\}]*\}/g, '');
 
         // figure out what kind of format we are dealing with
-        if (format.indexOf('$') > -1) { // currency!!!!!
+        if (escapedFormat.indexOf('$') > -1) { // currency!!!!!
             output = formatCurrency(n, format, roundingFunction);
-        } else if (format.indexOf('%') > -1) { // percentage
+        } else if (escapedFormat.indexOf('%') > -1) { // percentage
             output = formatPercentage(n, format, roundingFunction);
-        } else if (format.indexOf(':') > -1) { // time
+        } else if (escapedFormat.indexOf(':') > -1) { // time
             output = formatTime(n, format);
         } else { // plain ol' numbers or bytes
             output = formatNumber(n._value, format, roundingFunction);

--- a/tests/numbro/format.js
+++ b/tests/numbro/format.js
@@ -72,9 +72,6 @@ exports.format = {
                 [3124213.12341234, '0.*', '3124213.12341234'],
                 [3124213.12341234, ',0.*', '3,124,213.12341234'],
 
-                [100, '{foo }0o', 'foo 100th'],
-                [100, '0o{ foo}', '100th foo'],
-
                 [1, '000', '001'],
                 [10, '000', '010'],
                 [100, '000', '100'],
@@ -453,6 +450,54 @@ exports.format = {
 
         for (i = 0; i < tests.length; i++) {
             test.strictEqual(numbro(tests[i][0]).formatCurrency(), tests[i][1], tests[i][1]);
+        }
+
+        numbro.culture(currentCulture);
+        test.done();
+    },
+
+    escape: function (test) {
+        var i;
+        var currentCulture = numbro.culture();
+
+        numbro.culture('test7', {
+            delimiters: {
+                thousands: ',',
+                decimal: '.'
+            },
+            abbreviations: {
+                thousand: 'k',
+                million: 'm',
+                billion: 'b',
+                trillion: 't'
+            },
+            ordinal: function(number) {
+              return "th";
+            },
+            currency: {
+                symbol: '€',
+                position: 'prefix'
+            }
+        });
+
+        numbro.culture('test7');
+
+
+        var tests = [
+            [100, '$0', '€100'],
+            [100, '{$}0', '$100'],
+            [100, '{foo }0o', 'foo 100th'],
+            [100, '0o{ foo}', '100th foo'],
+            [100, '{$  }0', '$  100'],
+            [100, '0{%}', '100%'],
+            [100, '0{:}', '100:'],
+            [100,'0{b}','100b']
+        ];
+
+        test.expect(tests.length);
+
+        for (i = 0; i < tests.length; i++) {
+            test.strictEqual(numbro(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
         }
 
         numbro.culture(currentCulture);


### PR DESCRIPTION
#103 introduced new syntax to allow escaping of verbatim text. For example, `'0{foo}'` would format `100` as `'100foo'` (where the unescaped `'0foo'` would have produced `'100th'`).

This fell down when the string contained some special characters, even if they were escaped. For example, `'{$}0'` would produce `'£100'` in the `en-GB` culture, rather than the expected `$100`.

This is a simple hack to add special handling for those characters to make sure escaping applies to them too.

| Number | Format | Before  | After |
|:------:|:------:|:-------:|:-----:|
|  100   | '{$}0' |  €100   | $100  |
|  100   | '0{%}' |  10000% | 100%  |
|  100   | '0{:}' | 0:01:40 | 100:  |