### PR TITLE
Limit packaging extraneous files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,14 @@
   },
   "scripts": {
     "test": "grunt test"
-  }
+  },
+  "files": [
+    "LICENSE",
+    "LICENSE-Numeraljs",
+    "CHANGELOG",
+    "CHANGELOG-Numeraljs.md",
+    "numbro.js",
+    "languages",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Numbro includes a lot of extra unneeded files such as the contents of the `_site` directory. This PR limits the files uploaded to npm.

### Current Files (result of `npm install`)
```
--- /Users/Mark/projects/numbro-test/node_modules/numbro ----------------------------------------------------------------
    5.4 MiB [##########] /_site                                                                                          
  284.0 KiB [          ] /dist
  196.0 KiB [          ] /tests
  148.0 KiB [          ] /languages
  116.0 KiB [          ] /resources
   40.0 KiB [          ]  numbro.js
    8.0 KiB [          ]  .jshintrc
    8.0 KiB [          ]  Gruntfile.js
    4.0 KiB [          ]  CHANGELOG.md
    4.0 KiB [          ]  CHANGELOG-Numeraljs.md
    4.0 KiB [          ]  package.json
    4.0 KiB [          ]  README.md
    4.0 KiB [          ]  LICENSE
    4.0 KiB [          ]  LICENSE-Numeraljs
    4.0 KiB [          ]  .npmignore
    4.0 KiB [          ]  component.json
    4.0 KiB [          ]  bower.json
    4.0 KiB [          ]  .travis.yml
    4.0 KiB [          ]  .jshintignore
```

### Changes
I elected to retain the LICENSE* and CHANGELOG* files and include the `dist` and `languages` directories (recursive). The `tests`, `resources`,  `_site` folders aren't normally useful to developers so they won't be uploaded.

`package.json` will be included automatically by `npm`.

See https://docs.npmjs.com/files/package.json#files