### PR TITLE
fix(format): making sure to add unit to 0 bytes

### DIFF
--- a/dist/numbro.js
+++ b/dist/numbro.js
@@ -1022,7 +1022,7 @@
     function inNodejsRuntime() {
         return (typeof process !== 'undefined') &&
             (process.browser === undefined) &&
-            (process.title === 'node' || process.title === 'grunt' || process.title === 'gulp') &&
+            (process.title.indexOf('node') === 0 || process.title === 'grunt' || process.title === 'gulp') &&
             (typeof require !== 'undefined');
     }
 

--- a/languages/fr-CA.js
+++ b/languages/fr-CA.js
@@ -25,7 +25,8 @@
         },
         currency: {
             symbol: '$',
-            position: 'prefix'
+            position: 'postfix',
+            spaceSeparated : true
         },
         defaults: {
             currencyFormat: ',4 a'

--- a/numbro.js
+++ b/numbro.js
@@ -572,6 +572,9 @@
                     break;
                 }
             }
+            if (bytes === '' || bytes === ' ') {
+                bytes = bytes + 'B';
+            }
         }
 
         // see if we are formatting decimal bytes

--- a/numbro.js
+++ b/numbro.js
@@ -1019,7 +1019,7 @@
     function inNodejsRuntime() {
         return (typeof process !== 'undefined') &&
             (process.browser === undefined) &&
-            (process.title === 'node' || process.title === 'grunt' || process.title === 'gulp') &&
+            (process.title.indexOf('node') === 0 || process.title === 'grunt' || process.title === 'gulp') &&
             (typeof require !== 'undefined');
     }
 

--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
     }
   ],
   "devDependencies": {
-    "grunt": "0.4.5",
-    "grunt-bump": "latest",
-    "grunt-confirm": "latest",
-    "grunt-contrib-concat": "latest",
-    "grunt-contrib-copy": "latest",
-    "grunt-contrib-jshint": "latest",
-    "grunt-contrib-nodeunit": "latest",
-    "grunt-contrib-uglify": "latest",
-    "grunt-jscs": "^1.8.0",
-    "grunt-release": "latest",
-    "uglify-js": "latest"
+    "grunt": "^1.0.1",
+    "grunt-bump": "^0.8.0",
+    "grunt-confirm": "^1.0.5",
+    "grunt-contrib-concat": "^1.0.1",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0",
+    "grunt-contrib-uglify": "^1.0.1",
+    "grunt-jscs": "^2.8.0",
+    "grunt-release": "^0.13.1",
+    "uglify-js": "^2.6.2"
   },
   "scripts": {
     "test": "grunt test"

--- a/tests/languages/fr-CA.js
+++ b/tests/languages/fr-CA.js
@@ -46,17 +46,18 @@ exports['culture:fr'] = {
     },
 
     currency: function (test) {
-        test.expect(4);
+        test.expect(5);
 
         var tests = [
             [1000.234,'0,0.00 $','1 000,23 $'],
             [-1000.234,'(0,0 $)','(1 000 $)'],
             [-1000.234,'0.00 $','-1000,23 $'],
-            [1230974,'(0.00 a$)','1,23 M$']
+            [1230974,'(0.00 a$)','1,23 M$'],
+            [1000.234,'0,0.00','1 000,23 $']
         ];
 
         for (var i = 0; i < tests.length; i++) {
-            test.strictEqual(numbro(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+            test.strictEqual(numbro(tests[i][0]).formatCurrency(tests[i][1]), tests[i][2], tests[i][1]);
         }
 
         test.done();

--- a/tests/numbro/format.js
+++ b/tests/numbro/format.js
@@ -524,6 +524,7 @@ exports.format = {
 
     bytes: function (test) {
         var tests = [
+                [0,'0 b','0 B'],
                 [100,'0b','100B'],
                 [1024*2,'0 b','2 KiB'],
                 [1024*1024*5,'0b','5MiB'],


### PR DESCRIPTION
refer: #171 

Adds a check to ensure a unit is present if `b` format is specified. This should fix issues with `0` not receiving a unit suffix on format. Let me know if I should be approaching this issue differently. I tried to follow the existing code style.

Will add in tests shortly.

EDIT: test added. Let me know if you need anything changed for this.