### PR TITLE
Fix undefined error on React native

### DIFF
--- a/numbro.js
+++ b/numbro.js
@@ -1043,6 +1043,7 @@
     function inNodejsRuntime() {
         return (typeof process !== 'undefined') &&
             (process.browser === undefined) &&
+            process.title &&
             (process.title.indexOf('node') === 0 || process.title === 'grunt' || process.title === 'gulp') &&
             (typeof require !== 'undefined');
     }


### PR DESCRIPTION
On React native it seems there is no title attached to the process, which causes an undefined error.
With this additional verification, it can be used on React Native.