### PR TITLE
Fixed wrong results from formatForeignCurrency

### DIFF
--- a/numbro.js
+++ b/numbro.js
@@ -275,7 +275,7 @@
         if(format.indexOf('$') === -1){
             // Use defaults instead of the format provided
             if (cultures[currentCulture].currency.position === 'infix') {
-                decimalSeparator = cultures[currentCulture].currency.symbol;
+                decimalSeparator = currencySymbol;
                 if (cultures[currentCulture].currency.spaceSeparated) {
                     decimalSeparator = ' ' + decimalSeparator + ' ';
                 }
@@ -304,10 +304,10 @@
                 case 'postfix':
                     if (output.indexOf(')') > -1) {
                         output = output.split('');
-                        output.splice(-1, 0, space + cultures[currentCulture].currency.symbol);
+                        output.splice(-1, 0, space + currencySymbol);
                         output = output.join('');
                     } else {
-                        output = output + space + cultures[currentCulture].currency.symbol;
+                        output = output + space + currencySymbol;
                     }
                     break;
                 case 'infix':
@@ -317,10 +317,10 @@
                         output = output.split('');
                         spliceIndex = Math.max(openParenIndex, minusSignIndex) + 1;
 
-                        output.splice(spliceIndex, 0, cultures[currentCulture].currency.symbol + space);
+                        output.splice(spliceIndex, 0, currencySymbol + space);
                         output = output.join('');
                     } else {
-                        output = cultures[currentCulture].currency.symbol + space + output;
+                        output = currencySymbol + space + output;
                     }
                     break;
                 default:

--- a/tests/numbro/format.js
+++ b/tests/numbro/format.js
@@ -274,10 +274,25 @@ exports.format = {
             ],
             i;
 
-        test.expect(tests.length);
+        var testsWithoutFormatString = [
+                [0.1,'$','0,1 $'],
+                [25,'$','25 $'],
+                [107, '$', '107 $'],
+                [9288,'$','9.288 $'],
+                [10965, '$','10,97 k$']
+            ],
+            j;
+
+        test.expect(tests.length + testsWithoutFormatString.length);
 
         for (i = 0; i < tests.length; i++) {
             test.strictEqual(numbro(tests[i][0]).formatForeignCurrency(tests[i][1], tests[i][2]), tests[i][3], tests[i][2]);
+        }
+
+        numbro.culture('de-DE');
+
+        for (j = 0; j < testsWithoutFormatString.length; j++) {
+            test.strictEqual(numbro(testsWithoutFormatString[j][0]).formatForeignCurrency(testsWithoutFormatString[j][1]), testsWithoutFormatString[j][2]);
         }
 
         numbro.culture(currentCulture);


### PR DESCRIPTION
Calls to formatForeignCurrency returned wrong results when these calls were made without passing a format string.

This PR fixes this problems and adds the necessary test cases.