### PR TITLE
update package.json license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,7 @@
   "bugs": {
     "url": "https://github.com/foretagsplatsen/numbro/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license" : "MIT",
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-bump": "^0.8.0",


### PR DESCRIPTION
This fixes the warning from `npm` about not having a license field when the package is installing.

```
npm WARN package.json numbro@1.9.3 No license field.
```

The old format of a `licenses` object was [deprecated](https://docs.npmjs.com/files/package.jsoen#license).