### PR TITLE
Fix index.js generation for culture neutral codes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,7 +152,8 @@ module.exports = function(grunt) {
             return 'exports[\'' + file.replace('.js', '') + '\'] = require(\'./' + file + '\');';
         }).join('\n');
 
-        fs.writeFileSync(dir + '/index.js', langFiles);
+        fs.writeFileSync(dir + '/index.js', '/* jshint sub: true */\n');
+        fs.appendFileSync(dir + '/index.js', langFiles);
     });
 
     // Travis CI task.


### PR DESCRIPTION
E.g., for culture code 'nn', it will put

exports.nn = require('./nn.js')j;

into the index.js. Without this change, it fails at build time due to a lint rule