### PR TITLE
Fallback ultimately to english

### DIFF
--- a/numbro.js
+++ b/numbro.js
@@ -812,7 +812,7 @@
                 if (key.indexOf('-') >= 0) {
                     return numbro.language(parentCulture(key));
                 } else {
-                    throw new Error('Unknown language : ' + key);
+                    key = 'en-US';
                 }
             }
             chooseCulture(key);
@@ -840,7 +840,7 @@
                 if (code.indexOf('-') >= 0) {
                     return numbro.culture(parentCulture(code));
                 } else {
-                    throw new Error('Unknown culture : ' + code);
+                    code = 'en-US';
                 }
             }
             chooseCulture(code);

--- a/numbro.js
+++ b/numbro.js
@@ -782,6 +782,17 @@
     };
 
     /**
+     * Get the parent culture from the passed in culture code
+     * e.g. fr-FR -> fr
+     *
+     * @param {string} code
+     * @returns {string} parent culture
+     */
+    function parentCulture(code) {
+        return code.substring(0, code.lastIndexOf('-'));
+    }
+
+    /**
      * This function will load languages and then set the global language.  If
      * no arguments are passed in, it will simply return the current global
      * language key.
@@ -798,7 +809,11 @@
 
         if (key && !values) {
             if (!languages[key]) {
-                throw new Error('Unknown language : ' + key);
+                if (key.indexOf('-') >= 0) {
+                    return numbro.language(parentCulture(key));
+                } else {
+                    throw new Error('Unknown language : ' + key);
+                }
             }
             chooseCulture(key);
         }
@@ -822,7 +837,11 @@
 
         if (code && !values) {
             if (!cultures[code]) {
-                throw new Error('Unknown culture : ' + code);
+                if (code.indexOf('-') >= 0) {
+                    return numbro.culture(parentCulture(code));
+                } else {
+                    throw new Error('Unknown culture : ' + code);
+                }
             }
             chooseCulture(code);
         }

--- a/tests/languages/fallback.js
+++ b/tests/languages/fallback.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var numbro = require('../../numbro');
+
+numbro.culture('en', {
+    langLocaleCode: 'en',
+    cultureCode: 'en',
+    delimiters: {
+        thousands: ',',
+        decimal: '.'
+    },
+    abbreviations: {
+        thousand: 'k',
+        million: 'm',
+        billion: 'b',
+        trillion: 't'
+    },
+    ordinal: function (number) {
+        var b = number % 10;
+        return (~~(number % 100 / 10) === 1) ? 'th' :
+            (b === 1) ? 'st' :
+                (b === 2) ? 'nd' :
+                    (b === 3) ? 'rd' : 'th';
+    },
+    currency: {
+        symbol: '$'
+    }
+});
+
+exports.misc = {
+    fallback: function (test) {
+        test.expect(1);
+        numbro.culture('en-foo');
+        var currentCulture = numbro.culture();
+
+        test.ok(currentCulture === 'en', 'Expect culturecode: ' + currentCulture);
+        test.done();
+    }
+};

--- a/tests/languages/fallback.js
+++ b/tests/languages/fallback.js
@@ -35,5 +35,23 @@ exports.misc = {
 
         test.ok(currentCulture === 'en', 'Expect culturecode: ' + currentCulture);
         test.done();
+    },
+    missing_culture: function (test) {
+        test.expect(1);
+        numbro.culture('zz-foo');
+
+        var currentCulture = numbro.culture();
+
+        test.ok(currentCulture === 'en-US', 'Expect culturecode: ' + currentCulture);
+        test.done();
+    },
+    missing_language: function (test) {
+        test.expect(1);
+        numbro.language('zz-foo');
+
+        var currentCulture = numbro.language();
+
+        test.ok(currentCulture === 'en-US', 'Expect culturecode: ' + currentCulture);
+        test.done();
     }
 };


### PR DESCRIPTION
For the language() and culture() methods, if there is no fallback possible instead of throwing, fallback to en-US. This is the same behaviour as setCulture() and setLanguage() so it seems reasonable behaviour to expect.