### PR TITLE
en-IN localization and customizable grouping

### DIFF
--- a/languages/en-IN.js
+++ b/languages/en-IN.js
@@ -1,0 +1,54 @@
+/*!
+ * numbro.js language configuration
+ * language : English
+ * locale: India
+ * author : Gwyn Judd https://github.com/gwynjudd
+ */
+(function () {
+    'use strict';
+
+    var language = {
+        langLocaleCode: 'en-IN',
+        cultureCode: 'en-IN',
+        delimiters: {
+            thousands: ',',
+            decimal: '.',
+            group: [2,3]
+        },
+        abbreviations: {
+            thousand: 'k',
+            million: 'm',
+            billion: 'b',
+            trillion: 't'
+        },
+        ordinal: function (number) {
+            var b = number % 10;
+            return (~~ (number % 100 / 10) === 1) ? 'th' :
+                (b === 1) ? 'st' :
+                (b === 2) ? 'nd' :
+                (b === 3) ? 'rd' : 'th';
+        },
+        currency: {
+            symbol: 'Rs.',
+            position: 'prefix'
+        },
+        defaults: {
+            currencyFormat: ',4 a'
+        },
+        formats: {
+            fourDigits: '4 a',
+            fullWithTwoDecimals: '$ ,0.00',
+            fullWithTwoDecimalsNoCurrency: ',0.00',
+            fullWithNoDecimals: '$ ,0'
+        }
+    };
+
+    // CommonJS
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = language;
+    }
+    // Browser
+    if (typeof window !== 'undefined' && window.numbro && window.numbro.culture) {
+        window.numbro.culture(language.cultureCode, language);
+    }
+}.call(typeof window === 'undefined' ? this : window));

--- a/numbro.js
+++ b/numbro.js
@@ -685,7 +685,18 @@
         }
 
         if (thousands > -1) {
-            w = w.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1' +
+            var re = '(?!\\d))';
+
+            var group = cultures[currentCulture].delimiters.group || [3];
+            for (var groupIndex = group.length-1; groupIndex >= 0; groupIndex--) {
+                var repeat = (groupIndex === 0 ? (group.length > 1 ? '*' : '+') : '');
+                re = '(?:\\d{' + group[groupIndex] + '})' + repeat + re;
+            }
+
+            re = '(\\d)(?=' + re;
+            re = new RegExp(re, 'g');
+
+            w = w.toString().replace(re, '$1' +
                 cultures[currentCulture].delimiters.thousands);
         }
 

--- a/tests/languages/en-IN.js
+++ b/tests/languages/en-IN.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var numbro = require('../../numbro'),
+    culture = require('../../languages/en-IN');
+
+numbro.culture(culture.langLocaleCode, culture);
+
+exports['culture:en-IN'] = {
+    setUp: function (callback) {
+        numbro.culture('en-IN');
+        callback();
+    },
+
+    tearDown: function (callback) {
+        numbro.culture('en-US');
+        callback();
+    },
+
+    format: function (test) {
+        test.expect(17);
+
+        var tests = [
+            [10000,'0,0.0000','10,000.0000'],
+            [100000,'0,0.0000','1,00,000.0000'],
+            [10000.23,'0,0','10,000'],
+            [-10000,'0,0.0','-10,000.0'],
+            [10000.1234,'0.000','10000.123'],
+            [-10000,'(0,0.0000)','(10,000.0000)'],
+            [-0.23,'.00','-.23'],
+            [-0.23,'(.00)','(.23)'],
+            [0.23,'0.00000','0.23000'],
+            [1230974,'0.0a','1.2m'],
+            [1460,'0a','1k'],
+            [-104000,'0a','-104k'],
+            [1,'0o','1st'],
+            [52,'0o','52nd'],
+            [23,'0o','23rd'],
+            [100,'0o','100th'],
+            [1,'0[.]0','1']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numbro(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    currency: function (test) {
+        test.expect(4);
+
+        var tests = [
+            [1000.234,'$0,0.00','Rs.1,000.23'],
+            [-1000.234,'($0,0)','(Rs.1,000)'],
+            [-1000.234,'$0.00','-Rs.1000.23'],
+            [1230974,'($0.00a)','Rs.1.23m']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numbro(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    percentages: function (test) {
+        test.expect(4);
+
+        var tests = [
+            [1,'0%','100%'],
+            [0.974878234,'0.000%','97.488%'],
+            [-0.43,'0%','-43%'],
+            [0.43,'(0.000%)','43.000%']
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numbro(tests[i][0]).format(tests[i][1]), tests[i][2], tests[i][1]);
+        }
+
+        test.done();
+    },
+
+    unformat: function (test) {
+        test.expect(10);
+
+        var tests = [
+            ['10,00,000.123',1000000.123],
+            ['10,000.123',10000.123],
+            ['(0.12345)',-0.12345],
+            ['(£1.23m)',-1230000],
+            ['10k',10000],
+            ['-10k',-10000],
+            ['23rd',23],
+            ['£10,000.00',10000],
+            ['-76%',-0.76],
+            ['2:23:57',8637]
+        ];
+
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numbro().unformat(tests[i][0]), tests[i][1], tests[i][0]);
+        }
+
+        test.done();
+    }
+};


### PR DESCRIPTION
Helps to address the grouping issues in #2 and #235 

Added support for customizable grouping widths. In the delimiters, specify group: [2,3], then format() will group like this

12,00,00,000

To make this work, we build up the grouping regex according to the group configuration. For en-IN, we get this:

/(\d)(?=(?:\d{2})*(?:\d{3})(?!\d))/

It matches a single digit, followed by non capturing look-ahead that matches zero or more 2 digit groups, followed by a 3 digit group.

The default for the group property is [3] which matches the current behaviour of grouping by thousands.

It should be possible to pass [4] and get grouping by ten thousands for e.g. Japanese. I'm not aware of more complex groupings.