### PR TITLE
#278 Initial implementation of numbro.unformat("NaN") and numbro.unformat("Infinity")

### DIFF
--- a/tests/numbro/unformat.js
+++ b/tests/numbro/unformat.js
@@ -9,7 +9,7 @@ exports.unformat = {
     },
 
     numbers: function (test) {
-        test.expect(20);
+        test.expect(32);
 
         var tests = [
                 ['10,000.123', 10000.123],
@@ -19,6 +19,18 @@ exports.unformat = {
                 ['31st', 31],
                 ['1.23t', 1230000000000],
                 ['N/A', 0],
+                ['NaN', NaN],
+                ['NaN%', NaN],
+                ['NaN %', NaN],
+                ['$NaN', NaN],
+                ['Infinity', Infinity],
+                ['$Infinity', Infinity],
+                ['Infinity%', Infinity],
+                ['Infinity %', Infinity],
+                ['-Infinity', -Infinity],
+                ['-$Infinity', -Infinity],
+                ['-Infinity%', -Infinity],
+                ['-Infinity %', -Infinity],
 
                 // Invalid strings which don't represent a number are converted
                 // to undefined.


### PR DESCRIPTION
Initial implementation of unformatting NaN and Infinity.

Currently only works for $ currency formats. Waiting for discussion on
whether or not it is wrong that these are formated with these symbols
for NaN and Infinity, as this will make this change easier.